### PR TITLE
Publish glue

### DIFF
--- a/agsol-borsh-schema/Cargo.toml
+++ b/agsol-borsh-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agsol-borsh-schema"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]
@@ -17,7 +17,7 @@ anyhow = { version = "1.0", optional = true }
 heck = { version = "0.3.3", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 quote = { version = "1.0", optional = true }
-syn = { version = "1.0", optional = true }
+syn = { version = "1.0", features = ["full", "parsing"], optional = true }
 
 [dev-dependencies]
 borsh = "0.9.1"

--- a/agsol-glue/Cargo.toml
+++ b/agsol-glue/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "1.0"
 env_logger = "0.9.0"
 log = "0.4"
 structopt = "0.3"
-agsol-borsh-schema = { version = "0.0.1", path = "../agsol-borsh-schema", features = ["full"] }
+agsol-borsh-schema = { version = "0.0.2", path = "../agsol-borsh-schema", features = ["full"] }

--- a/agsol-glue/Cargo.toml
+++ b/agsol-glue/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]
+description = "Tool for generating TS schema and wasm bindings from solana contracts"
 repository = "https://github.com/agoraxyz/agora-solana"
 
 [dependencies]
@@ -11,4 +12,4 @@ anyhow = "1.0"
 env_logger = "0.9.0"
 log = "0.4"
 structopt = "0.3"
-agsol-borsh-schema = { path = "../agsol-borsh-schema", features = ["full"] }
+agsol-borsh-schema = { version = "0.0.1", path = "../agsol-borsh-schema", features = ["full"] }


### PR DESCRIPTION
## Description
`agsol-borsh-schema` v0.0.2 had to be published because of missing `full` and `parsing` feature flags for `syn`.