### PR TITLE
I6 testbench unwraps

### DIFF
--- a/agsol-borsh-schema/test-output/schema.ts
+++ b/agsol-borsh-schema/test-output/schema.ts
@@ -6,29 +6,6 @@ import { borshPublicKey } from "./extensions/publicKey";
 
 borshPublicKey();
 
-export class BTreeWrapper extends Struct {
-    map0: Map<[32], PublicKey>;
-    map1: Map<string, number | null>;
-    map2: Map<number, string>;
-};
-
-export class TestStruct extends Struct {
-    fieldA: BN;
-    fieldB: number;
-    fieldC: OtherState[] | null;
-};
-
-export class OtherState extends Struct {
-    amount: BN;
-    timestamp: BN;
-};
-
-export class TupleStruct extends Struct {
-    unnamed_0: number;
-    unnamed_1: number;
-    unnamed_2: OtherState;
-};
-
 export class RandomStruct extends Struct {
     fieldA: string;
     fieldB: [2] | null;
@@ -73,46 +50,30 @@ export class TestEnumVariantG extends Struct {
     zello: boolean;
 };
 
+export class TestStruct extends Struct {
+    fieldA: BN;
+    fieldB: number;
+    fieldC: OtherState[] | null;
+};
+
+export class OtherState extends Struct {
+    amount: BN;
+    timestamp: BN;
+};
+
+export class TupleStruct extends Struct {
+    unnamed_0: number;
+    unnamed_1: number;
+    unnamed_2: OtherState;
+};
+
+export class BTreeWrapper extends Struct {
+    map0: Map<[32], PublicKey>;
+    map1: Map<string, number | null>;
+    map2: Map<number, string>;
+};
+
 export const SCHEMA = new Map<any, any>([
-    [
-            BTreeWrapper,
-            {
-                kind: 'struct', fields: [
-			['map0', { kind: 'map', key: [32], value: 'publicKey' }],
-			['map1', { kind: 'map', key: 'string', value: { kind: 'option', type: 'u32' } }],
-			['map2', { kind: 'map', key: 'u16', value: 'string' }],
-                ],
-            },
-    ],
-    [
-            TestStruct,
-            {
-                kind: 'struct', fields: [
-			['fieldA', 'u64'],
-			['fieldB', 'u8'],
-			['fieldC', { kind: 'option', type: [OtherState] }],
-                ],
-            },
-    ],
-    [
-            OtherState,
-            {
-                kind: 'struct', fields: [
-			['amount', 'u64'],
-			['timestamp', 'u64'],
-                ],
-            },
-    ],
-    [
-            TupleStruct,
-            {
-                kind: 'struct', fields: [
-			['unnamed_0', 'u8'],
-			['unnamed_1', 'u32'],
-			['unnamed_2', OtherState],
-                ],
-            },
-    ],
     [
             RandomStruct,
             {
@@ -190,6 +151,45 @@ export const SCHEMA = new Map<any, any>([
 			['bello', ['publicKey', 3]],
 			['yello', 'u16'],
 			['zello', 'u8'],
+                ],
+            },
+    ],
+    [
+            TestStruct,
+            {
+                kind: 'struct', fields: [
+			['fieldA', 'u64'],
+			['fieldB', 'u8'],
+			['fieldC', { kind: 'option', type: [OtherState] }],
+                ],
+            },
+    ],
+    [
+            OtherState,
+            {
+                kind: 'struct', fields: [
+			['amount', 'u64'],
+			['timestamp', 'u64'],
+                ],
+            },
+    ],
+    [
+            TupleStruct,
+            {
+                kind: 'struct', fields: [
+			['unnamed_0', 'u8'],
+			['unnamed_1', 'u32'],
+			['unnamed_2', OtherState],
+                ],
+            },
+    ],
+    [
+            BTreeWrapper,
+            {
+                kind: 'struct', fields: [
+			['map0', { kind: 'map', key: [32], value: 'publicKey' }],
+			['map1', { kind: 'map', key: 'string', value: { kind: 'option', type: 'u32' } }],
+			['map2', { kind: 'map', key: 'u16', value: 'string' }],
                 ],
             },
     ],

--- a/agsol-testbench/Cargo.toml
+++ b/agsol-testbench/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Agora DAO <mark@gold.xyz>"]
 repository = "https://github.com/agoraxyz/agora-solana"
 
 [dependencies]
+anyhow = "1"
 borsh = "0.9.0"
 serde = "1.0"
 solana-program = "1.9.0"
@@ -15,3 +16,4 @@ solana-program-test = "1.9.0"
 solana-sdk = "1.9.0"
 # update this once spl-token v3.2+ is out (wasm compatiblity issue)
 spl-token = { git = "https://github.com/zgendao/solana-program-library.git", features = ["no-entrypoint"] }
+thiserror = "1.0"

--- a/agsol-testbench/Cargo.toml
+++ b/agsol-testbench/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Agora DAO <mark@gold.xyz>"]
 repository = "https://github.com/agoraxyz/agora-solana"
 
 [dependencies]
-anyhow = "1"
 borsh = "0.9.0"
 serde = "1.0"
 solana-program = "1.9.0"

--- a/agsol-testbench/src/error.rs
+++ b/agsol-testbench/src/error.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum TestbenchError {
-    #[error(transparent)]
-    TransactionError(#[from] solana_sdk::transaction::TransactionError),
+    #[error("Could not fetch rent")]
+    RentError,
     #[error("Warping error")]
     WarpingError,
     #[error("Account not found")]

--- a/agsol-testbench/src/error.rs
+++ b/agsol-testbench/src/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum TestbenchError {
+    #[error(transparent)]
+    TransactionError(#[from] solana_sdk::transaction::TransactionError),
+    #[error("Warping error")]
+    WarpingError,
+    #[error("Account not found")]
+    AccountNotFound,
+    #[error("Deserialize error")]
+    CouldNotDeserialize,
+    #[error("Could not fetch latest blockhash")]
+    BlockhashError,
+}

--- a/agsol-testbench/src/lib.rs
+++ b/agsol-testbench/src/lib.rs
@@ -59,10 +59,12 @@
 //! # }
 //! ```
 
+mod error;
 mod test_user;
 mod testbench;
 mod testbench_program;
 
+pub use error::TestbenchError;
 pub use solana_program_test::{self, tokio};
 pub use test_user::TestUser;
 pub use testbench::Testbench;

--- a/agsol-testbench/src/lib.rs
+++ b/agsol-testbench/src/lib.rs
@@ -67,5 +67,5 @@ mod testbench_program;
 pub use error::TestbenchError;
 pub use solana_program_test::{self, tokio};
 pub use test_user::TestUser;
-pub use testbench::Testbench;
+pub use testbench::{Testbench, TestbenchResult, TestbenchTransactionResult};
 pub use testbench_program::TestbenchProgram;

--- a/agsol-testbench/src/lib.rs
+++ b/agsol-testbench/src/lib.rs
@@ -52,10 +52,10 @@
 //! };
 //!
 //! // load programs into the test context
-//! let mut testbench = Testbench::new(&[program_from_processor, program_from_binary]).await;
+//! let mut testbench = Testbench::new(&[program_from_processor, program_from_binary]).await.unwrap();
 //!
 //! // create a test user with an airdrop
-//! let test_user = TestUser::new(&mut testbench).await;
+//! let test_user = TestUser::new(&mut testbench).await.unwrap().unwrap();
 //! # }
 //! ```
 

--- a/agsol-testbench/src/test_user.rs
+++ b/agsol-testbench/src/test_user.rs
@@ -25,6 +25,6 @@ impl TestUser {
         testbench
             .process_transaction(&[instruction], &payer, None)
             .await
-            .map(|transaction_result| transaction_result.map(|_| Self { keypair } ))
+            .map(|transaction_result| transaction_result.map(|_| Self { keypair }))
     }
 }

--- a/agsol-testbench/src/test_user.rs
+++ b/agsol-testbench/src/test_user.rs
@@ -1,4 +1,4 @@
-use crate::Testbench;
+use crate::{Testbench, TestbenchTransactionResult};
 use solana_program::system_instruction;
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::signer::Signer;
@@ -10,7 +10,7 @@ pub struct TestUser {
 
 impl TestUser {
     /// Creates a new user and sends an airdrop to its address.
-    pub async fn new(testbench: &mut Testbench) -> Self {
+    pub async fn new(testbench: &mut Testbench) -> TestbenchTransactionResult<Self> {
         let keypair = Keypair::new();
 
         // send lamports to user
@@ -25,8 +25,6 @@ impl TestUser {
         testbench
             .process_transaction(&[instruction], &payer, None)
             .await
-            .unwrap();
-
-        Self { keypair }
+            .map(|transaction_result| transaction_result.map(|_| Self { keypair } ))
     }
 }

--- a/agsol-testbench/src/testbench.rs
+++ b/agsol-testbench/src/testbench.rs
@@ -1,4 +1,4 @@
-use crate::TestbenchProgram;
+use crate::{TestbenchError, TestbenchProgram};
 use borsh::BorshDeserialize;
 use solana_program::borsh::try_from_slice_unchecked;
 use solana_program::clock::UnixTimestamp;
@@ -6,14 +6,17 @@ use solana_program::program_pack::Pack;
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
 use solana_program_test::{BanksClient, ProgramTest, ProgramTestContext};
+use solana_sdk::account::Account;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::system_instruction;
-use solana_sdk::transaction::{Transaction, TransactionError};
+use solana_sdk::transaction::Transaction;
 
 use spl_token::instruction as token_instruction;
 use spl_token::state::{Account as TokenAccount, Mint};
+
+use anyhow::Context;
 
 /// Testbench wrapper around a [`ProgramTestContext`].
 pub struct Testbench {
@@ -24,7 +27,7 @@ pub struct Testbench {
 impl Testbench {
     /// Create new `Testbench` by loading [`TestbenchProgram`]s into a
     /// [`ProgramTest`] context.
-    pub async fn new(programs: &[TestbenchProgram<'_>]) -> Self {
+    pub async fn new(programs: &[TestbenchProgram<'_>]) -> Result<Self, anyhow::Error> {
         let mut program_test = ProgramTest::default();
 
         for program in programs {
@@ -32,9 +35,13 @@ impl Testbench {
         }
 
         let mut context = program_test.start_with_context().await;
-        let rent = context.banks_client.get_rent().await.unwrap();
+        let rent = context
+            .banks_client
+            .get_rent()
+            .await
+            .context("could not fetch rent while constructing testbench")?;
 
-        Self { context, rent }
+        Ok(Self { context, rent })
     }
 
     pub fn client(&mut self) -> &mut BanksClient {
@@ -46,46 +53,65 @@ impl Testbench {
     }
 
     pub fn clone_payer(&self) -> Keypair {
+        // unwrap is fine here because it is guaranteed to be a correct keypair
         Keypair::from_bytes(self.context.payer.to_bytes().as_ref()).unwrap()
     }
 
-    // TODO make this nicer?
-    pub async fn block_time(&mut self) -> UnixTimestamp {
-        let clock_sysvar = self
-            .client()
-            .get_account(solana_program::sysvar::clock::id())
+    pub async fn get_account(
+        &mut self,
+        account_pubkey: &Pubkey,
+    ) -> Result<Account, TestbenchError> {
+        self.client()
+            .get_account(*account_pubkey)
             .await
-            .unwrap() // result
-            .unwrap(); // option
-        solana_sdk::account::from_account::<solana_program::clock::Clock, _>(&clock_sysvar)
-            .unwrap()
-            .unix_timestamp
+            .map_err(|_| TestbenchError::AccountNotFound)? // result
+            .ok_or(TestbenchError::AccountNotFound) // option
     }
 
-    pub fn warp_to_slot(&mut self, slot: u64) {
-        self.context.warp_to_slot(slot).unwrap()
+    // TODO make this nicer?
+    pub async fn block_time(&mut self) -> Result<UnixTimestamp, TestbenchError> {
+        let clock_sysvar = self
+            .get_account(&solana_program::sysvar::clock::id())
+            .await?;
+        Ok(
+            solana_sdk::account::from_account::<solana_program::clock::Clock, _>(&clock_sysvar)
+                .ok_or(TestbenchError::CouldNotDeserialize)?
+                .unix_timestamp,
+        )
     }
 
-    pub async fn get_current_slot(&mut self) -> u64 {
-        self.context.banks_client.get_root_slot().await.unwrap()
+    pub fn warp_to_slot(&mut self, slot: u64) -> Result<(), TestbenchError> {
+        self.context
+            .warp_to_slot(slot)
+            .map_err(|_| TestbenchError::WarpingError)
     }
 
-    pub async fn warp_n_slots(&mut self, n: u64) {
-        let current_slot = self.get_current_slot().await;
-        self.warp_to_slot(current_slot + n);
+    pub async fn get_current_slot(&mut self) -> Result<u64, TestbenchError> {
+        Ok(self
+            .context
+            .banks_client
+            .get_root_slot()
+            .await
+            .map_err(|_| TestbenchError::WarpingError)?)
     }
 
-    pub async fn warp_n_seconds(&mut self, n: i64) {
-        let clock_start = self.block_time().await;
-        let mut clock_curr = self.block_time().await;
+    pub async fn warp_n_slots(&mut self, n: u64) -> Result<(), TestbenchError> {
+        let current_slot = self.get_current_slot().await?;
+        self.warp_to_slot(current_slot + n)
+    }
+
+    pub async fn warp_n_seconds(&mut self, n: i64) -> Result<(), TestbenchError> {
+        let clock_start = self.block_time().await?;
+        let mut clock_curr = self.block_time().await?;
         while clock_curr < clock_start + n {
-            self.warp_n_slots(n as u64 * 5).await;
-            clock_curr = self.block_time().await;
+            self.warp_n_slots(n as u64).await?;
+            clock_curr = self.block_time().await?;
         }
+        Ok(())
     }
 
-    pub async fn warp_to_finalize(&mut self) {
-        self.warp_n_slots(2).await;
+    pub async fn warp_to_finalize(&mut self) -> Result<(), TestbenchError> {
+        self.warp_n_slots(2).await
     }
 
     pub async fn process_transaction(
@@ -93,13 +119,13 @@ impl Testbench {
         instructions: &[Instruction],
         payer: &Keypair,
         signers: Option<&[&Keypair]>,
-    ) -> Result<(), TransactionError> {
+    ) -> Result<(), TestbenchError> {
         let latest_blockhash = self
             .context
             .banks_client
             .get_latest_blockhash()
             .await
-            .unwrap();
+            .map_err(|_| TestbenchError::BlockhashError)?;
 
         let mut transaction = Transaction::new_with_payer(instructions, Some(&payer.pubkey()));
         let mut all_signers = vec![payer];
@@ -109,20 +135,23 @@ impl Testbench {
 
         transaction.sign(&all_signers, latest_blockhash);
 
-        // TransportError has an unwrap method that turns it into a
-        // TransactionError
+        // TransportError has an unwrap method that turns it into a TransactionError
         self.context
             .banks_client
             .process_transaction(transaction)
             .await
             .map_err(|e| e.unwrap())?;
 
-        self.warp_to_finalize().await;
+        self.warp_to_finalize().await?;
 
         Ok(())
     }
 
-    pub async fn create_mint(&mut self, decimals: u8, mint_authority: &Pubkey) -> Pubkey {
+    pub async fn create_mint(
+        &mut self,
+        decimals: u8,
+        mint_authority: &Pubkey,
+    ) -> Result<Pubkey, TestbenchError> {
         let mint_keypair = Keypair::new();
         let mint_rent = self.rent.minimum_balance(Mint::LEN);
         let instructions = [
@@ -133,6 +162,7 @@ impl Testbench {
                 Mint::LEN as u64,
                 &spl_token::id(),
             ),
+            // unwrap is fine here because initialize_mint only throws error if the token program id is incorrect
             token_instruction::initialize_mint(
                 &spl_token::id(),
                 &mint_keypair.pubkey(),
@@ -145,13 +175,16 @@ impl Testbench {
 
         let payer = self.clone_payer();
         self.process_transaction(&instructions, &payer, Some(&[&mint_keypair]))
-            .await
-            .unwrap();
+            .await?;
 
-        mint_keypair.pubkey()
+        Ok(mint_keypair.pubkey())
     }
 
-    pub async fn create_token_holding_account(&mut self, owner: &Keypair, mint: &Pubkey) -> Pubkey {
+    pub async fn create_token_holding_account(
+        &mut self,
+        owner: &Keypair,
+        mint: &Pubkey,
+    ) -> Result<Pubkey, TestbenchError> {
         let account_keypair = Keypair::new();
         let mint_rent = self.rent.minimum_balance(TokenAccount::LEN);
         let instructions = [
@@ -162,6 +195,7 @@ impl Testbench {
                 TokenAccount::LEN as u64,
                 &spl_token::id(),
             ),
+            // unwrap is fine here because initialize_mint only throws error if the token program id is incorrect
             token_instruction::initialize_account(
                 &spl_token::id(),
                 &account_keypair.pubkey(),
@@ -173,13 +207,18 @@ impl Testbench {
 
         let payer = self.clone_payer();
         self.process_transaction(&instructions, &payer, Some(&[owner, &account_keypair]))
-            .await
-            .unwrap();
+            .await?;
 
-        account_keypair.pubkey()
+        Ok(account_keypair.pubkey())
     }
 
-    pub async fn mint_to_account(&mut self, mint: &Pubkey, account: &Pubkey, amount: u64) {
+    pub async fn mint_to_account(
+        &mut self,
+        mint: &Pubkey,
+        account: &Pubkey,
+        amount: u64,
+    ) -> Result<(), TestbenchError> {
+        // unwrap is fine here because mint_to only throws error if the token program id is incorrect
         let instruction = token_instruction::mint_to(
             &spl_token::id(),
             mint,
@@ -192,70 +231,68 @@ impl Testbench {
 
         let signer = self.clone_payer();
         self.process_transaction(&[instruction], &signer, Some(&[&signer]))
-            .await
-            .unwrap();
+            .await?;
+
+        Ok(())
     }
 
-    pub async fn token_balance(&mut self, token_account: &Pubkey) -> u64 {
+    pub async fn token_balance(&mut self, token_account: &Pubkey) -> Result<u64, TestbenchError> {
         let data: TokenAccount = self
             .client()
             .get_packed_account_data(*token_account)
             .await
-            .unwrap();
+            .map_err(|_| TestbenchError::AccountNotFound)?;
 
-        data.amount
+        Ok(data.amount)
     }
 
-    pub async fn total_supply(&mut self, mint_account: &Pubkey) -> u64 {
+    pub async fn total_supply(&mut self, mint_account: &Pubkey) -> Result<u64, TestbenchError> {
         let data: Mint = self
             .client()
             .get_packed_account_data(*mint_account)
             .await
-            .unwrap();
+            .map_err(|_| TestbenchError::AccountNotFound)?;
 
-        data.supply
+        Ok(data.supply)
     }
 
-    pub async fn get_account_lamports(&mut self, account_pubkey: &Pubkey) -> u64 {
-        self.client()
-            .get_account(*account_pubkey)
-            .await
-            .unwrap()
-            .unwrap()
-            .lamports
+    pub async fn get_account_lamports(
+        &mut self,
+        account_pubkey: &Pubkey,
+    ) -> Result<u64, TestbenchError> {
+        Ok(self.get_account(account_pubkey).await?.lamports)
     }
 
-    pub async fn get_account_data(&mut self, account_pubkey: &Pubkey) -> Vec<u8> {
-        self.client()
-            .get_account(*account_pubkey)
-            .await
-            .unwrap()
-            .unwrap()
-            .data
+    pub async fn get_account_data(
+        &mut self,
+        account_pubkey: &Pubkey,
+    ) -> Result<Vec<u8>, TestbenchError> {
+        Ok(self.get_account(account_pubkey).await?.data)
     }
 
     pub async fn get_and_deserialize_account_data<T: BorshDeserialize>(
         &mut self,
         account_pubkey: &Pubkey,
-    ) -> T {
-        let account_data = self.get_account_data(account_pubkey).await;
-        try_from_slice_unchecked(account_data.as_slice()).unwrap()
+    ) -> Result<T, TestbenchError> {
+        let account_data = self.get_account_data(account_pubkey).await?;
+        try_from_slice_unchecked(account_data.as_slice())
+            .map_err(|_| TestbenchError::CouldNotDeserialize)
     }
 
     pub async fn get_token_account(
         &mut self,
         account_pubkey: &Pubkey,
-    ) -> Result<TokenAccount, String> {
-        self.client()
-            .get_packed_account_data(*account_pubkey)
-            .await
-            .map_err(|e| e.to_string())
+    ) -> Result<TokenAccount, TestbenchError> {
+        let account_data = self.get_account_data(account_pubkey).await?;
+        TokenAccount::unpack_from_slice(&account_data)
+            .map_err(|_| TestbenchError::CouldNotDeserialize)
     }
 
-    pub async fn get_mint_account(&mut self, account_pubkey: &Pubkey) -> Result<Mint, String> {
-        self.client()
-            .get_packed_account_data(*account_pubkey)
-            .await
-            .map_err(|e| e.to_string())
+    pub async fn get_mint_account(
+        &mut self,
+        account_pubkey: &Pubkey,
+    ) -> Result<Mint, TestbenchError> {
+        let account_data = self.get_account_data(account_pubkey).await?;
+        Mint::unpack_from_slice(&account_data).map_err(|_| TestbenchError::CouldNotDeserialize)
     }
 }

--- a/agsol-testbench/src/testbench.rs
+++ b/agsol-testbench/src/testbench.rs
@@ -58,10 +58,7 @@ impl Testbench {
         Keypair::from_bytes(self.context.payer.to_bytes().as_ref()).unwrap()
     }
 
-    pub async fn get_account(
-        &mut self,
-        account_pubkey: &Pubkey,
-    ) -> TestbenchResult<Account> {
+    pub async fn get_account(&mut self, account_pubkey: &Pubkey) -> TestbenchResult<Account> {
         self.client()
             .get_account(*account_pubkey)
             .await
@@ -139,7 +136,8 @@ impl Testbench {
         // TransportError has an unwrap method that turns it into a TransactionError
 
         let payer_balance_before = self.get_account_lamports(&payer.pubkey()).await?;
-        let transaction_result = self.context
+        let transaction_result = self
+            .context
             .banks_client
             .process_transaction(transaction)
             .await
@@ -180,7 +178,6 @@ impl Testbench {
         self.process_transaction(&instructions, &payer, Some(&[&mint_keypair]))
             .await
             .map(|transaction_result| transaction_result.map(|_| mint_keypair.pubkey()))
-
     }
 
     pub async fn create_token_holding_account(
@@ -234,7 +231,7 @@ impl Testbench {
         let signer = self.clone_payer();
         self.process_transaction(&[instruction], &signer, Some(&[&signer]))
             .await
-            .map(|transaction_result| transaction_result.map(|_| () ))
+            .map(|transaction_result| transaction_result.map(|_| ()))
     }
 
     pub async fn token_balance(&mut self, token_account: &Pubkey) -> TestbenchResult<u64> {
@@ -257,17 +254,11 @@ impl Testbench {
         Ok(data.supply)
     }
 
-    pub async fn get_account_lamports(
-        &mut self,
-        account_pubkey: &Pubkey,
-    ) -> TestbenchResult<u64> {
+    pub async fn get_account_lamports(&mut self, account_pubkey: &Pubkey) -> TestbenchResult<u64> {
         Ok(self.get_account(account_pubkey).await?.lamports)
     }
 
-    pub async fn get_account_data(
-        &mut self,
-        account_pubkey: &Pubkey,
-    ) -> TestbenchResult<Vec<u8>> {
+    pub async fn get_account_data(&mut self, account_pubkey: &Pubkey) -> TestbenchResult<Vec<u8>> {
         Ok(self.get_account(account_pubkey).await?.data)
     }
 
@@ -289,10 +280,7 @@ impl Testbench {
             .map_err(|_| TestbenchError::CouldNotDeserialize)
     }
 
-    pub async fn get_mint_account(
-        &mut self,
-        account_pubkey: &Pubkey,
-    ) -> TestbenchResult<Mint> {
+    pub async fn get_mint_account(&mut self, account_pubkey: &Pubkey) -> TestbenchResult<Mint> {
         let account_data = self.get_account_data(account_pubkey).await?;
         Mint::unpack_from_slice(&account_data).map_err(|_| TestbenchError::CouldNotDeserialize)
     }

--- a/agsol-wasm-client-test/Cargo.toml
+++ b/agsol-wasm-client-test/Cargo.toml
@@ -15,8 +15,8 @@ borsh = "0.9"
 bs58 = "0.4"
 serde_json = "1.0"
 solana-program = "1.9.0"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen = "0.2.78"
+wasm-bindgen-futures = "0.4.28"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/agsol-wasm-client-test/src/lib.rs
+++ b/agsol-wasm-client-test/src/lib.rs
@@ -1,3 +1,7 @@
+// This is necessary because clippy throws 'unneeded unit expression' error
+// on the wasm_bindgen expressions
+#![allow(clippy::unused_unit)]
+
 use agsol_wasm_client::{wasm_instruction, Net, RpcClient};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::instruction::{AccountMeta, Instruction};


### PR DESCRIPTION
# Description

Aims to resolve #6 . Added `TestbenchError` to address possible error types while interacting with the Testbench. All functions which may fail with such errors now return values of type `TestbenchResult<T>` which is an alias introduced for `Result<T, TestbenchError>`.

Since processing a transaction may fail in other ways as well, all function calls using transactions return `TestbenchTransactionResult<T>` which is an alias of `Result<Result<T, TransactionError>, TestbenchError>`.