### PR TITLE
Different slots are returned with different commitments.

### DIFF
--- a/agsol-wasm-client-test/examples/block_time.rs
+++ b/agsol-wasm-client-test/examples/block_time.rs
@@ -1,0 +1,19 @@
+use agsol_wasm_client::rpc_config::{CommitmentLevel, Encoding, RpcConfig};
+use agsol_wasm_client::{Net, RpcClient};
+
+#[tokio::main]
+async fn main() {
+    let config = RpcConfig {
+        encoding: Some(Encoding::JsonParsed),
+        commitment: Some(CommitmentLevel::Confirmed),
+    };
+    let mut client = RpcClient::new_with_config(Net::Devnet, config);
+
+    loop {
+        let slot = client.get_slot().await.unwrap();
+        let block_time = client.get_block_time(slot).await.unwrap();
+
+        println!("{}", block_time);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/agsol-wasm-client/Cargo.toml
+++ b/agsol-wasm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agsol-wasm-client"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]

--- a/agsol-wasm-client/src/rpc_client.rs
+++ b/agsol-wasm-client/src/rpc_client.rs
@@ -175,7 +175,7 @@ impl RpcClient {
         // TODO for some reason latest blockhash returns method not found
         // even though we are using 1.9.0 and the rpc servers are also updated
         let request = RpcRequest::GetRecentBlockhash
-            .build_request_json(self.request_id, json!([]))
+            .build_request_json(self.request_id, json!([self.config]))
             .to_string();
 
         let response: RpcResponse<RpcResultWithContext<Blockhash>> = self.send(request).await?;
@@ -250,7 +250,7 @@ impl RpcClient {
 
     pub async fn get_slot(&mut self) -> ClientResult<Slot> {
         let request = RpcRequest::GetSlot
-            .build_request_json(self.request_id, json!([]))
+            .build_request_json(self.request_id, json!([self.config]))
             .to_string();
 
         let response: RpcResponse<Slot> = self.send(request).await?;


### PR DESCRIPTION
## Description
Querying the latest slot will result in a different slot for different commitment levels. However, the `get_slot` method didn't send any config parameters, so the rpc server used the default "finalized" setting which resulted in the wasm client being 10 seconds behind the webapp's clock.