### PR TITLE
Max len into

### DIFF
--- a/agsol-common/Cargo.toml
+++ b/agsol-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agsol-common"
-version = "0.2.2-alpha"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]

--- a/agsol-common/Cargo.toml
+++ b/agsol-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agsol-common"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]

--- a/agsol-common/Cargo.toml
+++ b/agsol-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agsol-common"
-version = "0.2.2"
+version = "0.2.2-alpha"
 edition = "2021"
 license = "MIT"
 authors = ["Agora DAO <mark@gold.xyz>"]

--- a/agsol-common/src/max_len_string.rs
+++ b/agsol-common/src/max_len_string.rs
@@ -2,7 +2,7 @@ use super::{MaxSerializedLen, CONTENTS_FULL};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use std::convert::TryFrom;
+use std::convert::{From, TryFrom};
 
 #[repr(C)]
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug)]
@@ -43,6 +43,12 @@ impl<const N: usize> TryFrom<&str> for MaxLenString<N> {
     }
 }
 
+impl<const N: usize> From<MaxLenString<N>> for String {
+    fn from(rhs: MaxLenString<N>) -> Self {
+        rhs.contents
+    }
+}
+
 #[cfg(test)]
 mod test_max_len_string {
     use super::*;
@@ -58,6 +64,8 @@ mod test_max_len_string {
         let string = "ASDEF".to_string();
         let max_len_string = TestString::try_from(string.clone()).unwrap();
         assert_eq!(string, max_len_string.contents);
+
+        assert_eq!(string_slice, String::from(max_len_string));
     }
 
     #[test]

--- a/agsol-common/src/max_len_vec.rs
+++ b/agsol-common/src/max_len_vec.rs
@@ -1,6 +1,6 @@
 use super::{MaxLenResult, MaxSerializedLen, CONTENTS_FULL};
 use borsh::{BorshDeserialize, BorshSerialize};
-use std::convert::TryFrom;
+use std::convert::{From, TryFrom};
 
 // NOTE anyhow doesn't compile under bpf it seems
 
@@ -104,6 +104,12 @@ impl<T, const N: usize> Default for MaxLenVec<T, N> {
     }
 }
 
+impl<T, const N: usize> From<MaxLenVec<T, N>> for Vec<T> {
+    fn from(rhs: MaxLenVec<T, N>) -> Self {
+        rhs.contents
+    }
+}
+
 #[cfg(test)]
 mod test_max_len_vec {
     use super::*;
@@ -165,6 +171,9 @@ mod test_max_len_vec {
         assert_eq!(vec.contents(), &[1, 2, 3, 4, 5]);
         vec.contents_mut()[2] = 10;
         assert_eq!(vec.contents(), &[1, 2, 10, 4, 5]);
+
+        let std_vec = Vec::<u8>::from(vec);
+        assert_eq!(std_vec, vec![1, 2, 10, 4, 5]);
     }
 
     #[test]


### PR DESCRIPTION
## Description
Turn `MaxLenString` and `MaxLenVec` into `String` and `Vec` types respectively, while consuming them.